### PR TITLE
Don't mutate default_key_list dict when key_list param is given

### DIFF
--- a/relationships/relationship.py
+++ b/relationships/relationship.py
@@ -9,9 +9,10 @@ class Relationship(object):
     def __init__(self, redis_connection=None, key_list=None, actor=None):
 
         if key_list:
-            default_key_list.update(key_list)
-
-        self.key_list = default_key_list
+            self.key_list = default_key_list.copy()
+            self.key_list.update(key_list)
+        else:
+            self.key_list = default_key_list
 
         if redis_connection:
             self.redis_connection = redis_connection


### PR DESCRIPTION
Since default_key_list is global, updating it _will_ affect future Relationship instances as well. This commit also preserves the original behaviour when key_list param is not given (it doesn't create new dict object unnecessarily).
