### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ relationships
 ---
 redis backed user relationships on its simplest form.
 
-####installation
+#### installation
 
 ```bash
 $ [sudo] pip install relationships
@@ -12,7 +12,7 @@ or if you like 90s:
 $ [sudo] easy_install relationships
 ```
 
-####usage
+#### usage
 
 **getting the Relationship class**
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
